### PR TITLE
Merge 'image' branch into master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ENV project_path=$project_path
 
 # Update and add java package
 RUN apt-get update
-RUN ((echo "Y")) | apt-get install default-jre
-RUN ((echo "Y")) | apt-get install openjfx
+# RUN ((echo "Y")) | apt-get install default-jre
+# RUN ((echo "Y")) | apt-get install openjfx
 
 # ///// HANDLE READY API /////
 # Create unpack directory, move test script into test folder, license JAR into licensing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # ///// INITIAL CONFIG /////
 # Linux image to run application on
-FROM ubuntu:16.04
+# FROM ubuntu:16.04
+FROM rburgst/java8-openjfx-docker:latest
 MAINTAINER Nathan Wright <nathan.wright@smartbear.com>
 
 # Build variable store

--- a/startup_test/basic-project-readyapi-project.xml
+++ b/startup_test/basic-project-readyapi-project.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<con:soapui-project id="2d1cf692-fcbb-466e-97ee-ec326245d545" created="2.3.0" activeEnvironment="Default environment" name="basic_project" resourceRoot="" updated="2.2.0 20171026-0943" encryptionMode="Not encrypted" xmlns:con="http://eviware.com/soapui/config">
-  <con:settings/>
+<con:soapui-project id="2d1cf692-fcbb-466e-97ee-ec326245d545" created="2.3.0" activeEnvironment="Default" name="basic_project" resourceRoot="" updated="2.3.0 2018-03-06T16:28:42Z" encryptionMode="Not encrypted" abortOnError="false" runType="SEQUENTIAL" soapui-version="5.4.0" xmlns:con="http://eviware.com/soapui/config">
+  <con:settings>
+    <con:setting id="Port">8081</con:setting>
+  </con:settings>
   <con:interface xsi:type="con:RestService" id="a97ebe4d-9059-4c45-8421-2f1b1d3e351c" wadlVersion="http://wadl.dev.java.net/2009/02" name="http://dl.eviware.com" type="rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <con:settings/>
     <con:definitionCache type="TEXT" rootPart=""/>
@@ -39,7 +41,7 @@
   <con:testSuite id="4ccbd3a7-4400-4147-bb48-76351e41fe61" name="basic_testsuite">
     <con:settings/>
     <con:runType>SEQUENTIAL</con:runType>
-    <con:testCase id="7ffc2ec6-5803-45f8-9650-2f4c4eeb0252" discardOkResults="true" failOnError="true" failTestCaseOnErrors="true" keepSession="false" name="single_request" searchProperties="true" timeout="0">
+    <con:testCase id="7ffc2ec6-5803-45f8-9650-2f4c4eeb0252" discardOkResults="true" failOnError="true" failTestCaseOnErrors="true" keepSession="false" name="single_request" searchProperties="true" timeout="0" maxResults="0">
       <con:settings/>
       <con:savedRecentRuns>1</con:savedRecentRuns>
       <con:testStep type="restrequest" name="Get 200" id="fe31bf49-43f1-4efe-8993-f4fa6c1464e5">

--- a/startup_test/basic-project-readyapi-project.xml
+++ b/startup_test/basic-project-readyapi-project.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<con:soapui-project id="2d1cf692-fcbb-466e-97ee-ec326245d545" created="2.3.0" activeEnvironment="Default" name="basic_project" resourceRoot="" updated="2.3.0 2018-03-06T16:28:42Z" encryptionMode="Not encrypted" abortOnError="false" runType="SEQUENTIAL" soapui-version="5.4.0" xmlns:con="http://eviware.com/soapui/config">
+<con:soapui-project id="2d1cf692-fcbb-466e-97ee-ec326245d545" created="2.3.0" activeEnvironment="Default environment" name="basic_project" resourceRoot="" updated="2.2.0 20171026-0943" encryptionMode="Not encrypted" abortOnError="false" runType="SEQUENTIAL" soapui-version="5.4.0" xmlns:con="http://eviware.com/soapui/config">
   <con:settings>
     <con:setting id="Port">8081</con:setting>
   </con:settings>


### PR DESCRIPTION
Verified that RAPI runs on the open-jfx/java8 base container. 

Initial build time reduced from ~5 minutes to 2 minutes, re-build time reduced from ~ 90 seconds to 12. 

Container size is about the same. 

Ready to merge into master.